### PR TITLE
Changed join_axes to .reindex in extract function

### DIFF
--- a/swmmtoolbox/swmmtoolbox.py
+++ b/swmmtoolbox/swmmtoolbox.py
@@ -797,7 +797,7 @@ def extract(filename, *labels):
                 ],
             )
         )
-    result = pd.concat(jtsd, axis=1, join_axes=[jtsd[0].index])
+    result = pd.concat(jtsd, axis=1).reindex(jtsd[0].index)
     return result
 
 


### PR DESCRIPTION
The join_axes keyword is deprecated