### PR TITLE
Main

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -23,7 +23,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 
@@ -70,7 +70,7 @@ jobs:
 
         steps:
             - name: Checkout source
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -80,7 +80,7 @@ jobs:
                   python -m build
 
             - name: Download artifact
-              uses: actions/download-artifact@v5
+              uses: actions/download-artifact@v6
               with:
                   path: dist
                   merge-multiple: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions workflows to use the latest major versions of core actions for packaging and tests.

CI:
- Bump actions/checkout from v5 to v6 in packaging and test workflows.
- Bump actions/download-artifact from v5 to v6 in the PyPI packaging workflow.